### PR TITLE
Add SeedKeeper keystore support

### DIFF
--- a/src/gui/screens/__init__.py
+++ b/src/gui/screens/__init__.py
@@ -8,3 +8,4 @@ from .input import PinScreen, InputScreen, DerivationScreen, NumericScreen
 from .mnemonic import MnemonicScreen, NewMnemonicScreen, RecoverMnemonicScreen
 from .transaction import TransactionScreen
 from .settings import DevSettings
+from .debug_info import DebugInfoScreen

--- a/src/gui/screens/debug_info.py
+++ b/src/gui/screens/debug_info.py
@@ -1,0 +1,80 @@
+"""Debug info screen shown during multi-keystore detection.
+
+Displays firmware version, card presence, and detected applets
+while polling for an available keystore in select_keystore().
+"""
+import lvgl as lv
+from .screen import Screen
+from ..common import add_label
+from ..core import update
+
+
+class DebugInfoScreen(Screen):
+    """Shows firmware version, card presence, and detected applets."""
+
+    def __init__(self):
+        super().__init__()
+        self.title = add_label("Specter Debug Info", scr=self, style="title")
+
+        self.version_label = add_label("", scr=self, style="hint")
+        self.version_label.align(self.title, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
+
+        self.card_label = add_label("Card: checking...", scr=self, style="small")
+        self.card_label.align(self.version_label, lv.ALIGN.OUT_BOTTOM_MID, 0, 30)
+
+        self.applets_label = add_label("Applets: --", scr=self, style="small")
+        self.applets_label.align(self.card_label, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
+
+        self.status_label = add_label("", scr=self, style="hint")
+        self.status_label.align(self.applets_label, lv.ALIGN.OUT_BOTTOM_MID, 0, 20)
+
+        self.hint_label = add_label("Waiting for keystore...", scr=self, style="hint")
+        self.hint_label.set_y(700)
+
+        self._set_firmware_info()
+
+    def load(self):
+        lv.scr_load(self)
+        update()
+
+    def _set_firmware_info(self):
+        try:
+            from platform import get_git_info, get_version
+            repo, branch, commit = get_git_info()
+            ver = get_version()
+            lines = "Firmware: %s" % ver
+            if branch != "unknown":
+                lines += "\nBranch: %s" % branch
+            if commit != "unknown":
+                lines += "\nCommit: %s" % commit
+            self.version_label.set_text(lines)
+        except Exception:
+            self.version_label.set_text("Firmware: unknown")
+
+    def update_info(self, info: dict) -> None:
+        if not info:
+            info = {}
+
+        card_present = info.get("card_present", False)
+        applets = info.get("applets", [])
+        status = info.get("status", "")
+
+        if not isinstance(applets, (list, tuple)):
+            applets = []
+
+        if card_present:
+            self.card_label.set_text("Card: present")
+        else:
+            self.card_label.set_text("Card: not detected")
+
+        if applets:
+            self.applets_label.set_text("Applets:\n" + "\n".join(["  - " + str(a) for a in applets]))
+        else:
+            self.applets_label.set_text("Applets: (none detected)")
+
+        if status:
+            self.status_label.set_text(str(status))
+        else:
+            self.status_label.set_text("")
+
+        update()

--- a/src/hil.py
+++ b/src/hil.py
@@ -150,6 +150,21 @@ class HILCommandHandler:
             self._list_all_secrets()
             return
 
+        # TEST_IMPORT_SECRET:<hex_data>[:<label>] - import BIP39 secret to card
+        if line.startswith("TEST_IMPORT_SECRET:"):
+            self._import_secret(line[len("TEST_IMPORT_SECRET:"):])
+            return
+
+        # TEST_DELETE_SECRET:<sid> - delete secret by ID
+        if line.startswith("TEST_DELETE_SECRET:"):
+            self._delete_secret(line[len("TEST_DELETE_SECRET:"):])
+            return
+
+        # TEST_CARD_RESET - power cycle the smartcard (disconnect + reconnect)
+        if line == "TEST_CARD_RESET":
+            self._card_reset()
+            return
+
         # TEST_FINGERPRINT - get current keystore fingerprint
         if line == "TEST_FINGERPRINT":
             self._get_fingerprint()
@@ -343,3 +358,56 @@ class HILCommandHandler:
         except Exception as e:
             log_exception("HIL", e)
             self._respond("ERR:ALL_SECRETS_FAIL")
+
+    def _import_secret(self, args):
+        try:
+            from binascii import unhexlify
+            ks = _get_keystore()
+            if ks is None or not hasattr(ks, 'applet'):
+                self._respond("ERR:NO_SEEDKEEPER")
+                return
+            parts = args.split(":", 1)
+            hex_data = parts[0].strip()
+            label = parts[1].strip() if len(parts) > 1 else ""
+            secret_data = unhexlify(hex_data)
+            sid, fp = ks.applet.import_secret(secret_data, secret_type=0x30, label=label)
+            self._respond("OK:IMPORT:%d:%s" % (sid, fp))
+        except Exception as e:
+            log_exception("HIL", e)
+            self._respond("ERR:IMPORT_FAIL:%s" % str(e))
+
+    def _delete_secret(self, sid_str):
+        try:
+            ks = _get_keystore()
+            if ks is None or not hasattr(ks, 'applet'):
+                self._respond("ERR:NO_SEEDKEEPER")
+                return
+            sid = int(sid_str.strip())
+            ks.applet.delete_secret(sid)
+            self._respond("OK:DELETED:%d" % sid)
+        except Exception as e:
+            log_exception("HIL", e)
+            self._respond("ERR:DELETE_FAIL:%s" % str(e))
+
+    def _card_reset(self):
+        try:
+            import time as _time
+            from keystore.javacard.util import get_connection
+            ks = _get_keystore()
+            conn = get_connection()
+            try:
+                conn.disconnect()
+            except Exception:
+                pass
+            _time.sleep_ms(500)
+            conn.connect(conn.T1_protocol)
+            if ks is not None and hasattr(ks, 'applet'):
+                ks.applet.select()
+                ks.applet.init_secure_channel()
+                ks.applet.verify_pin(ks._last_pin or "1234")
+                ks.connected = True
+                ks._pin_unlocked = True
+            self._respond("OK:CARD_RESET")
+        except Exception as e:
+            log_exception("HIL", e)
+            self._respond("ERR:CARD_RESET_FAIL:%s" % str(e))

--- a/src/hil.py
+++ b/src/hil.py
@@ -140,6 +140,16 @@ class HILCommandHandler:
             self._wipe_storage()
             return
 
+        # TEST_SECRETS - list BIP39 secret IDs and labels from SeedKeeper
+        if line == "TEST_SECRETS":
+            self._list_secrets()
+            return
+
+        # TEST_ALL_SECRETS - list ALL secrets (including descriptors, passwords, etc.)
+        if line == "TEST_ALL_SECRETS":
+            self._list_all_secrets()
+            return
+
         # TEST_FINGERPRINT - get current keystore fingerprint
         if line == "TEST_FINGERPRINT":
             self._get_fingerprint()
@@ -284,3 +294,52 @@ class HILCommandHandler:
         except Exception as e:
             log_exception("HIL", e)
             self._respond("ERR:MNEMONIC_FAIL")
+
+    def _list_secrets(self):
+        try:
+            ks = _get_keystore()
+            if ks is None or not hasattr(ks, 'applet'):
+                self._respond("ERR:NO_SEEDKEEPER")
+                return
+            headers = ks.applet.list_secret_headers()
+            bip39 = [
+                h for h in headers
+                if h['type'] in (0x10, 0x30, 0x31)
+                and (h['type'] != 0x10 or h.get('subtype') == 1)
+            ]
+            parts = []
+            for h in bip39:
+                label = h.get('label', '')
+                if not isinstance(label, str) or len(label) == 0:
+                    label = 'Secret #%d' % h['id']
+                fp = h.get('fingerprint', '????????')
+                parts.append("%d:%s:%s" % (h['id'], label, fp))
+            self._respond("OK:SECRETS:%s" % ",".join(parts))
+        except Exception as e:
+            log_exception("HIL", e)
+            self._respond("ERR:SECRETS_FAIL")
+
+    def _list_all_secrets(self):
+        try:
+            ks = _get_keystore()
+            if ks is None or not hasattr(ks, 'applet'):
+                self._respond("ERR:NO_SEEDKEEPER")
+                return
+            headers = ks.applet.list_secret_headers()
+            type_names = {
+                0x10: "MASTERSEED", 0x30: "BIP39", 0x31: "BIP39v2",
+                0x40: "ELECTRUM", 0x90: "PASSWORD", 0xC0: "DATA",
+                0xC1: "DESCRIPTOR",
+            }
+            parts = []
+            for h in headers:
+                label = h.get('label', '')
+                if not isinstance(label, str) or len(label) == 0:
+                    label = 'Secret #%d' % h['id']
+                tname = type_names.get(h['type'], "0x%02x" % h['type'])
+                fp = h.get('fingerprint', '????????')
+                parts.append("%d:%s:%s:%s" % (h['id'], tname, label, fp))
+            self._respond("OK:ALL_SECRETS:%s" % ",".join(parts))
+        except Exception as e:
+            log_exception("HIL", e)
+            self._respond("ERR:ALL_SECRETS_FAIL")

--- a/src/keystore/javacard/applets/satochip_securechannel.py
+++ b/src/keystore/javacard/applets/satochip_securechannel.py
@@ -1,0 +1,136 @@
+"""
+Satochip Secure Channel - Crypto primitives for SeedKeeper and Satochip applets.
+
+Implements ECDH key exchange, AES-CBC encryption, and HMAC-SHA1 authentication.
+This is the Satochip/SeedKeeper protocol, distinct from MemoryCard's SecureChannel
+(which uses HMAC-SHA256 and a different key derivation scheme).
+"""
+
+import hashlib
+import secp256k1
+from ucryptolib import aes
+from rng import get_random_bytes
+
+
+AES_BLOCK = 16
+
+
+def hmac_sha1(key: bytes, msg: bytes) -> bytes:
+    BLOCK_SIZE = 64
+    if len(key) > BLOCK_SIZE:
+        key = hashlib.sha1(key).digest()
+    elif len(key) < BLOCK_SIZE:
+        key = key + b'\x00' * (BLOCK_SIZE - len(key))
+    ipad = b'\x36' * BLOCK_SIZE
+    opad = b'\x5c' * BLOCK_SIZE
+    key_ipad = bytes(a ^ b for a, b in zip(key, ipad))
+    key_opad = bytes(a ^ b for a, b in zip(key, opad))
+    inner_hash = hashlib.sha1(key_ipad + msg).digest()
+    return hashlib.sha1(key_opad + inner_hash).digest()
+
+
+def pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
+    pad_len = block_size - (len(data) % block_size)
+    return data + bytes([pad_len] * pad_len)
+
+
+def pkcs7_unpad(data: bytes) -> bytes:
+    padding_len = data[-1]
+    if padding_len == 0:
+        raise ValueError("Invalid PKCS#7 padding")
+    for i in range(1, padding_len + 1):
+        if data[-i] != padding_len:
+            raise ValueError("Invalid PKCS#7 padding")
+    return data[:-padding_len]
+
+
+class SatochipSecureChannel:
+    """Secure channel for Satochip/SeedKeeper JavaCard applets.
+
+    ECDH key exchange with AES-CBC encryption and HMAC-SHA1 authentication.
+    """
+
+    def __init__(self):
+        self.aes_key = None
+        self.mac_key = None
+        self.iv_counter = 1
+        self.is_initialized = False
+
+    def initiate(self, connection, cla=0xB0):
+        """Perform ECDH key exchange via INS 0x81."""
+        try:
+            from platform import hil_test_mode
+        except Exception:
+            hil_test_mode = False
+        secret = get_random_bytes(32)
+        if hil_test_mode:
+            from debug_trace import log
+            log("SC", "ECDH: generating pubkey...")
+        pubkey = secp256k1.ec_pubkey_create(secret)
+        pub_bytes = secp256k1.ec_pubkey_serialize(pubkey, secp256k1.EC_UNCOMPRESSED)
+
+        apdu = bytes([cla, 0x81, 0x00, 0x00, 0x41]) + pub_bytes
+        if hil_test_mode:
+            log("SC", "ECDH: transmitting %d bytes..." % len(apdu))
+        data = connection.transmit(apdu)
+        if hil_test_mode:
+            log("SC", "ECDH: got response, len=%d" % len(data))
+        resp_data = data[0]
+        sw1, sw2 = data[1], data[2]
+        if hil_test_mode:
+            log("SC", "ECDH: SW=%02X%02X" % (sw1, sw2))
+        if sw1 != 0x90 or sw2 != 0x00:
+            raise ValueError('INIT_SC failed: SW={:02X}{:02X}'.format(sw1, sw2))
+
+        if hil_test_mode:
+            log("SC", "ECDH: parsing card pubkey...")
+        coordx_size = (resp_data[0] << 8) | resp_data[1]
+        coordx = bytes(resp_data[2:2 + coordx_size])
+
+        card_pubkey_compressed = bytes([0x02]) + coordx
+        if hil_test_mode:
+            log("SC", "ECDH: computing shared secret...")
+        card_pubkey = secp256k1.ec_pubkey_parse(card_pubkey_compressed)
+
+        shared_point = secp256k1.ec_pubkey_parse(
+            secp256k1.ec_pubkey_serialize(card_pubkey)
+        )
+        secp256k1.ec_pubkey_tweak_mul(shared_point, secret)
+        shared_bytes = secp256k1.ec_pubkey_serialize(shared_point, secp256k1.EC_UNCOMPRESSED)
+        shared_secret = shared_bytes[1:33]
+
+        self.aes_key = hmac_sha1(shared_secret, b'sc_key')[:16]
+        self.mac_key = hmac_sha1(shared_secret, b'sc_mac')
+        self.is_initialized = True
+        if hil_test_mode:
+            log("SC", "ECDH: secure channel initialized")
+
+    def encrypt_apdu(self, inner_apdu: bytes, cla=0xB0) -> bytes:
+        if not self.is_initialized:
+            raise ValueError("Secure channel not initialized")
+
+        iv = get_random_bytes(12) + self.iv_counter.to_bytes(4, 'big')
+        if iv[15] % 2 == 0:
+            iv = iv[:15] + bytes([iv[15] | 0x01])
+
+        padded = pkcs7_pad(inner_apdu, AES_BLOCK)
+        cipher = aes(self.aes_key, 2, iv)
+        ciphertext = cipher.encrypt(padded)
+
+        mac_data = iv + len(ciphertext).to_bytes(2, 'big') + ciphertext
+        mac = hmac_sha1(self.mac_key, mac_data)
+
+        payload = iv + len(ciphertext).to_bytes(2, 'big') + ciphertext + (20).to_bytes(2, 'big') + mac
+        wrapped = bytes([cla, 0x82, 0x00, 0x00, len(payload)]) + payload
+
+        self.iv_counter += 2
+        return wrapped
+
+    def decrypt_response(self, encrypted_response: bytes) -> bytes:
+        card_iv = encrypted_response[:16]
+        data_size = int.from_bytes(encrypted_response[16:18], 'big')
+        ciphertext = encrypted_response[18:18 + data_size]
+
+        cipher = aes(self.aes_key, 2, card_iv)
+        plaintext = cipher.decrypt(ciphertext)
+        return pkcs7_unpad(plaintext)

--- a/src/keystore/javacard/applets/satochip_securechannel.py
+++ b/src/keystore/javacard/applets/satochip_securechannel.py
@@ -55,6 +55,7 @@ class SatochipSecureChannel:
         self.mac_key = None
         self.iv_counter = 1
         self.is_initialized = False
+        self.card_pubkey = None
 
     def initiate(self, connection, cla=0xB0):
         """Perform ECDH key exchange via INS 0x81."""
@@ -88,9 +89,9 @@ class SatochipSecureChannel:
         coordx = bytes(resp_data[2:2 + coordx_size])
 
         card_pubkey_compressed = bytes([0x02]) + coordx
-        if hil_test_mode:
-            log("SC", "ECDH: computing shared secret...")
+
         card_pubkey = secp256k1.ec_pubkey_parse(card_pubkey_compressed)
+        self.card_pubkey = card_pubkey
 
         shared_point = secp256k1.ec_pubkey_parse(
             secp256k1.ec_pubkey_serialize(card_pubkey)
@@ -104,6 +105,13 @@ class SatochipSecureChannel:
         self.is_initialized = True
         if hil_test_mode:
             log("SC", "ECDH: secure channel initialized")
+
+    def reset(self):
+        self.aes_key = None
+        self.mac_key = None
+        self.iv_counter = 1
+        self.is_initialized = False
+        self.card_pubkey = None
 
     def encrypt_apdu(self, inner_apdu: bytes, cla=0xB0) -> bytes:
         if not self.is_initialized:

--- a/src/keystore/javacard/applets/seedkeeper_applet.py
+++ b/src/keystore/javacard/applets/seedkeeper_applet.py
@@ -20,6 +20,7 @@ class SeedKeeperApplet(Applet):
     INS_VERIFY_PIN = 0x42
     INS_CHANGE_PIN = 0x44
     INS_CARD_LABEL = 0x3D
+    INS_IMPORT_SECRET = 0xA1
     INS_EXPORT_SECRET = 0xA2
     INS_LIST_SECRETS = 0xA6
     INS_GET_STATUS = 0xA7
@@ -167,6 +168,62 @@ class SeedKeeperApplet(Applet):
         sid_bytes = bytes([(sid >> 8) & 0xFF, sid & 0xFF])
         apdu = bytes([self.CLA, self.INS_DELETE_SECRET, 0x00, 0x00, 0x02]) + sid_bytes
         self.secure_request(apdu)
+
+    def import_secret(self, secret_data, secret_type=0x30, label=""):
+        """Import a secret to the card using plaintext transport.
+
+        Multi-step INIT/PROCESS/FINALIZE protocol.
+        For BIP39: secret_data = entropy_len(2) || entropy bytes.
+
+        Returns: (secret_id, fingerprint_hex) tuple.
+        """
+        if isinstance(label, str):
+            label_bytes = label.encode("utf-8")
+        else:
+            label_bytes = bytes(label)
+        if len(label_bytes) > 127:
+            raise AppletException("Label too long (max 127 bytes)")
+
+        secret_len = len(secret_data)
+        padded_size = secret_len + (16 - secret_len % 16) % 16
+
+        header = bytes([
+            secret_type,
+            0x01,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00,
+            0x00,
+            len(label_bytes),
+        ])
+
+        init_data = header + label_bytes + bytes([padded_size >> 8, padded_size & 0xFF])
+        init_apdu = bytes([self.CLA, self.INS_IMPORT_SECRET, 0x01, 0x01, len(init_data)]) + init_data
+        resp = self.secure_request(init_apdu)
+
+        chunk_size = 128
+        offset = 0
+        while offset < secret_len:
+            remaining = secret_len - offset
+            size = min(chunk_size, remaining)
+            is_last = (offset + size >= secret_len)
+            p2 = 0x03 if is_last else 0x02
+            chunk = secret_data[offset:offset + size]
+            chunk_apdu = bytes([
+                self.CLA, self.INS_IMPORT_SECRET, 0x01, p2,
+                2 + len(chunk)
+            ]) + bytes([size >> 8, size & 0xFF]) + chunk
+            resp = self.secure_request(chunk_apdu)
+            offset += size
+
+        if len(resp) >= 6:
+            sid = (resp[0] << 8) | resp[1]
+            fp = hexlify(bytes(resp[2:6])).decode()
+            return sid, fp
+        raise AppletException("Import failed: unexpected response")
 
     def _parse_header(self, data):
         """Parse a 15+ byte secret header.

--- a/src/keystore/javacard/applets/seedkeeper_applet.py
+++ b/src/keystore/javacard/applets/seedkeeper_applet.py
@@ -1,0 +1,304 @@
+"""SeedKeeper JavaCard applet.
+
+APDU commands for SeedKeeper cards: PIN management, secret listing,
+export, card label, and status queries. Uses SatochipSecureChannel
+for encrypted communication.
+"""
+from .applet import Applet, ISOException, AppletException
+from .satochip_securechannel import SatochipSecureChannel
+from binascii import hexlify
+from embit import bip39
+
+
+class SeedKeeperApplet(Applet):
+    """Applet for communicating with SeedKeeper cards."""
+
+    AID = bytes([0x53, 0x65, 0x65, 0x64, 0x4B, 0x65, 0x65, 0x70, 0x65, 0x72])
+    NAME = "SeedKeeper"
+    CLA = 0xB0
+
+    INS_VERIFY_PIN = 0x42
+    INS_CHANGE_PIN = 0x44
+    INS_CARD_LABEL = 0x3D
+    INS_EXPORT_SECRET = 0xA2
+    INS_LIST_SECRETS = 0xA6
+    INS_GET_STATUS = 0xA7
+    INS_DELETE_SECRET = 0xA5
+
+    SECRET_TYPE_MASTERSEED = 0x10
+    SECRET_TYPE_BIP39 = 0x30
+    SECRET_TYPE_BIP39_V2 = 0x31
+    SECRET_TYPE_DESCRIPTOR = 0xC1
+
+    def __init__(self, connection):
+        super().__init__(connection, self.AID)
+        self.sc = SatochipSecureChannel()
+
+    def init_secure_channel(self):
+        """Initialize secure channel. Must be called after select()."""
+        self.sc.initiate(self.conn)
+
+    def secure_request(self, inner_apdu: bytes, retry: bool = True) -> bytes:
+        """Send APDU via secure channel (INS 0x82)."""
+        if not self.sc.is_initialized:
+            raise AppletException("Secure channel not initialized")
+
+        encrypted_apdu = self.sc.encrypt_apdu(inner_apdu)
+        data = self.conn.transmit(encrypted_apdu)
+        resp_data, sw1, sw2 = data[0], data[1], data[2]
+        sw = bytes([sw1, sw2])
+
+        if sw == b"\x9c\x30" and retry:
+            self.sc.initiate(self.conn)
+            encrypted_apdu = self.sc.encrypt_apdu(inner_apdu)
+            data = self.conn.transmit(encrypted_apdu)
+            resp_data, sw1, sw2 = data[0], data[1], data[2]
+            sw = bytes([sw1, sw2])
+
+        if sw != b"\x90\x00":
+            raise ISOException(hexlify(sw).decode())
+
+        if len(resp_data) > 0:
+            return self.sc.decrypt_response(resp_data)
+        return b''
+
+    def get_card_status(self):
+        """Get card status without secure channel (INS 0x3C)."""
+        apdu = bytes([self.CLA, 0x3C, 0x00, 0x00])
+        data = self.conn.transmit(apdu)
+        return data[0], data[1], data[2]
+
+    def get_seedkeeper_status(self):
+        """Get card status: secret count, memory usage, logs.
+        APDU: B0 A7 00 00
+        Response: [nb_secrets(2)][total_mem(2)][free_mem(2)][nb_logs_total(2)][nb_logs_avail(2)]
+        """
+        apdu = bytes([self.CLA, self.INS_GET_STATUS, 0x00, 0x00])
+        resp = self.secure_request(apdu)
+        if len(resp) >= 10:
+            return {
+                'nb_secrets': (resp[0] << 8) | resp[1],
+                'total_memory': (resp[2] << 8) | resp[3],
+                'free_memory': (resp[4] << 8) | resp[5],
+                'nb_logs_total': (resp[6] << 8) | resp[7],
+                'nb_logs_avail': (resp[8] << 8) | resp[9],
+            }
+        return {}
+
+    def verify_pin(self, pin):
+        """Verify PIN to unlock the card.
+        APDU: B0 42 00 00 [Lc] [PIN]
+        Returns: (success_bool, attempts_remaining_or_None)
+        """
+        if isinstance(pin, str):
+            pin = pin.encode()
+        inner_apdu = bytes([self.CLA, self.INS_VERIFY_PIN, 0x00, 0x00, len(pin)]) + pin
+        self.secure_request(inner_apdu)
+        return (True, None)
+
+    def change_pin(self, old_pin, new_pin):
+        """Change PIN on the card.
+        APDU: B0 44 00 00 [old_len(1)][old_pin][new_len(1)][new_pin]
+        """
+        if isinstance(old_pin, str):
+            old_pin = old_pin.encode()
+        if isinstance(new_pin, str):
+            new_pin = new_pin.encode()
+        apdu_data = bytes([len(old_pin)]) + old_pin + bytes([len(new_pin)]) + new_pin
+        inner_apdu = bytes([self.CLA, self.INS_CHANGE_PIN, 0x00, 0x00, len(apdu_data)]) + apdu_data
+        self.secure_request(inner_apdu)
+
+    def get_card_label(self):
+        """Read card label via INS 0x3D, p2=0x01."""
+        apdu = bytes([self.CLA, self.INS_CARD_LABEL, 0x00, 0x01, 0x00])
+        resp = self.secure_request(apdu)
+        if len(resp) == 0:
+            return ""
+        label_len = resp[0]
+        if label_len == 0 or len(resp) < 1 + label_len:
+            return ""
+        try:
+            return bytes(resp[1:1 + label_len]).decode("utf-8")
+        except Exception:
+            return hexlify(bytes(resp[1:1 + label_len])).decode()
+
+    def set_card_label(self, label):
+        """Set card label via INS 0x3D, p2=0x00."""
+        if label is None:
+            label = ""
+        if isinstance(label, str):
+            label_bytes = label.encode("utf-8")
+        else:
+            label_bytes = bytes(label)
+        if len(label_bytes) > 64:
+            raise AppletException("Card label too long (max 64 bytes)")
+        if len(label_bytes) == 0:
+            apdu = bytes([self.CLA, self.INS_CARD_LABEL, 0x00, 0x00, 0x00])
+        else:
+            payload = bytes([len(label_bytes)]) + label_bytes
+            apdu = bytes([self.CLA, self.INS_CARD_LABEL, 0x00, 0x00, len(payload)]) + payload
+        self.secure_request(apdu)
+
+    def list_secret_headers(self):
+        """List all secret headers using INIT/NEXT iteration.
+        Returns list of header dicts with id, type, label, fingerprint, etc.
+        """
+        headers = []
+        p2 = 0x01  # INIT
+        while True:
+            apdu = bytes([self.CLA, self.INS_LIST_SECRETS, 0x00, p2])
+            try:
+                resp = self.secure_request(apdu)
+            except ISOException as e:
+                if str(e) == "9c12":
+                    break
+                raise
+            if len(resp) == 0:
+                break
+            if len(resp) >= 15:
+                headers.append(self._parse_header(resp))
+            p2 = 0x02  # NEXT
+        return headers
+
+    def delete_secret(self, sid):
+        """Delete a secret by ID.
+        APDU: B0 A5 00 00 [sid_hi(1)][sid_lo(1)]
+        """
+        sid_bytes = bytes([(sid >> 8) & 0xFF, sid & 0xFF])
+        apdu = bytes([self.CLA, self.INS_DELETE_SECRET, 0x00, 0x00, 0x02]) + sid_bytes
+        self.secure_request(apdu)
+
+    def _parse_header(self, data):
+        """Parse a 15+ byte secret header.
+        Format: id(2)|type(1)|origin(1)|export_rights(1)|export_nbplain(1)|
+                export_nbsecure(1)|export_counter(1)|fingerprint(4)|subtype(1)|
+                rfu(1)|label_len(1)|label(N)
+        """
+        header = {
+            'id': (data[0] << 8) | data[1],
+            'type': data[2],
+            'origin': data[3],
+            'export_rights': data[4],
+            'export_nbplain': data[5],
+            'export_nbsecure': data[6],
+            'export_counter': data[7],
+            'fingerprint': hexlify(bytes(data[8:12])).decode(),
+            'subtype': data[12],
+            'rfu': data[13],
+            'label': ''
+        }
+        label_len = data[14]
+        if label_len > 0 and len(data) >= 15 + label_len:
+            try:
+                header['label'] = bytes(data[15:15 + label_len]).decode('utf-8')
+            except Exception:
+                header['label'] = hexlify(bytes(data[15:15 + label_len])).decode()
+        return header
+
+    def export_secret(self, sid, include_header=False):
+        """Export a secret by ID using multi-step INIT/UPDATE protocol.
+        Returns: full secret payload bytes.
+        """
+        sid_bytes = bytes([(sid >> 8) & 0xFF, sid & 0xFF])
+
+        # INIT - returns header only
+        apdu = bytes([self.CLA, self.INS_EXPORT_SECRET, 0x01, 0x01, 0x02]) + sid_bytes
+        resp = self.secure_request(apdu)
+
+        if len(resp) < 13:
+            return b''
+
+        header_label_len = resp[12]
+        chunks = []
+
+        chunk_num = 1
+        while True:
+            apdu = bytes([self.CLA, self.INS_EXPORT_SECRET, 0x01, 0x02, 0x02]) + sid_bytes
+            resp = self.secure_request(apdu)
+
+            if len(resp) < 2:
+                break
+
+            chunk_size = (resp[0] << 8) | resp[1]
+            if chunk_size > 0:
+                chunks.append(resp[2:2 + chunk_size])
+
+            # Last chunk has signature after data
+            response_size = len(resp)
+            if chunk_size + 2 < response_size:
+                break
+
+            chunk_num += 1
+            if chunk_num > 50:
+                break
+
+        return b''.join(chunks)
+
+    def _parse_masterseed_to_mnemonic(self, secret_data: bytes) -> str:
+        """Parse MASTERSEED format to BIP39 mnemonic.
+        Format: masterseed_size(1)|masterseed(N)|wordlist(1)|entropy_size(1)|entropy(M)
+        """
+        offset = 0
+        offset += 1 + secret_data[offset]  # skip masterseed
+        offset += 1  # skip wordlist
+        entropy_size = secret_data[offset]
+        offset += 1
+        entropy = secret_data[offset:offset + entropy_size]
+        return bip39.mnemonic_from_bytes(entropy)
+
+    def get_bip39_secret(self, secret_id=None, secret_type=None):
+        """Find and export a BIP39 secret, convert to mnemonic.
+        Returns: mnemonic string
+        """
+        if secret_id is not None:
+            if secret_type is None:
+                for h in self.list_secret_headers():
+                    if h['id'] == secret_id:
+                        secret_type = h['type']
+                        break
+            secret_data = self.export_secret(secret_id)
+            if secret_type == self.SECRET_TYPE_MASTERSEED:
+                return self._parse_masterseed_to_mnemonic(secret_data)
+            # BIP39 format: entropy_len(2) || entropy
+            if len(secret_data) >= 2:
+                entropy_len = (secret_data[0] << 8) | secret_data[1]
+                return bip39.mnemonic_from_bytes(secret_data[2:2 + entropy_len])
+            raise AppletException("Invalid BIP39 secret format")
+
+        # Default: search for first BIP39 or MASTERSEED secret
+        headers = self.list_secret_headers()
+        for h in headers:
+            if h['type'] in (self.SECRET_TYPE_BIP39, self.SECRET_TYPE_BIP39_V2, self.SECRET_TYPE_MASTERSEED):
+                secret_data = self.export_secret(h['id'])
+                if h['type'] == self.SECRET_TYPE_MASTERSEED:
+                    return self._parse_masterseed_to_mnemonic(secret_data)
+                if len(secret_data) >= 2:
+                    entropy_len = (secret_data[0] << 8) | secret_data[1]
+                    return bip39.mnemonic_from_bytes(secret_data[2:2 + entropy_len])
+
+        raise AppletException("No BIP39 or MASTERSEED secrets found on card")
+
+    def get_descriptor_secrets(self):
+        """Find and export all wallet descriptor secrets (type 0xC1)."""
+        headers = self.list_secret_headers()
+        descriptors = []
+        for h in headers:
+            if h['type'] == self.SECRET_TYPE_DESCRIPTOR:
+                try:
+                    secret_data = self.export_secret(h['id'])
+                    if len(secret_data) >= 2:
+                        desc_len = (secret_data[0] << 8) | secret_data[1]
+                        descriptor_str = secret_data[2:2 + desc_len].decode('utf-8', errors='replace')
+                        descriptors.append({
+                            'id': h['id'],
+                            'label': h['label'],
+                            'descriptor': descriptor_str
+                        })
+                except Exception:
+                    pass
+        return descriptors
+
+
+def _is_bip39_header(h):
+    """Check if a secret header represents a BIP39-compatible secret."""
+    return h['type'] in (0x10, 0x30, 0x31) and (h['type'] != 0x10 or h.get('subtype') == 1)

--- a/src/keystore/javacard/card_scanner.py
+++ b/src/keystore/javacard/card_scanner.py
@@ -1,0 +1,55 @@
+"""Utility to scan a smartcard for known applets.
+
+Probes the card for known JavaCard applets by attempting SELECT on each AID.
+Used by the debug info screen during multi-keystore detection polling.
+"""
+from .applets.applet import Applet
+
+
+KNOWN_APPLETS = [
+    ("SeedKeeper", bytes([0x53, 0x65, 0x65, 0x64, 0x4B, 0x65, 0x65, 0x70, 0x65, 0x72])),
+    ("MemoryCard", b"\xB0\x0B\x51\x11\xCB\x01"),
+]
+
+
+def scan_card_applets(connection) -> dict:
+    """Scan a smartcard for known applets.
+
+    Returns dict with card_present (bool), applets (list[str]), status (str).
+    Never raises exceptions to the caller.
+    """
+    result = {
+        "card_present": False,
+        "applets": [],
+        "status": ""
+    }
+    try:
+        if not connection.isCardInserted():
+            return result
+    except Exception:
+        return result
+
+    result["card_present"] = True
+    try:
+        connection.connect(connection.T1_protocol)
+    except Exception as e:
+        result["status"] = "Connect failed: " + str(e)
+        return result
+
+    detected = []
+    for name, aid in KNOWN_APPLETS:
+        try:
+            applet = Applet(connection, aid)
+            applet.select()
+            detected.append(name)
+        except Exception:
+            pass
+
+    try:
+        connection.disconnect()
+    except Exception:
+        pass
+
+    result["applets"] = detected
+    result["status"] = "%d applet(s) detected" % len(detected) if detected else "No known applets"
+    return result

--- a/src/keystore/memorycard.py
+++ b/src/keystore/memorycard.py
@@ -60,6 +60,10 @@ In this mode device can only operate when the smartcard is inserted!"""
             return True
         except Exception as e:
             print(e)
+            try:
+                cls.connection.disconnect()
+            except Exception:
+                pass
             return False
 
 

--- a/src/keystore/seedkeeper.py
+++ b/src/keystore/seedkeeper.py
@@ -1,0 +1,343 @@
+from .core import KeyStoreError, PinError
+from .ram import RAMKeyStore
+from .javacard.applets.seedkeeper_applet import SeedKeeperApplet, _is_bip39_header
+from .javacard.applets.applet import AppletException
+from .javacard.util import get_connection
+from platform import CriticalErrorWipeImmediately
+import platform
+from helpers import tagged_hash
+from gui.screens import Alert, Progress, Menu
+import asyncio
+
+
+class SeedKeeper(RAMKeyStore):
+    """
+    KeyStore that loads secrets from a SeedKeeper smartcard.
+    Read-only — secrets are generated and stored on the card, not saved from the device.
+    Multi-secret — card can hold multiple BIP39 secrets; user selects which to use.
+
+    Mirrors MemoryCard architecture: extends RAMKeyStore, manages its own
+    applet and connection, implements the same keystore interface.
+    """
+
+    NAME = "SeedKeeper"
+    COLOR = "FF8C00"
+    NOTE = "Loads Bitcoin key from a SeedKeeper smartcard (requires devkit)."
+    storage_button = "SeedKeeper storage"
+    load_button = "Load key from SeedKeeper"
+
+    connection = get_connection()
+
+    def __init__(self):
+        super().__init__()
+        self.applet = SeedKeeperApplet(self.connection)
+        self.connected = False
+        self._pin_unlocked = False
+        self.selected_secret_id = None
+        self._is_key_saved = False
+
+    @classmethod
+    def is_available(cls):
+        import time
+        time.sleep_ms(20)
+        if not cls.connection.isCardInserted():
+            return False
+        try:
+            cls.connection.connect(cls.connection.T1_protocol)
+            applet = SeedKeeperApplet(cls.connection)
+            applet.select()
+            applet.get_card_status()
+            cls.connection.disconnect()
+            return True
+        except Exception:
+            try:
+                cls.connection.disconnect()
+            except Exception:
+                pass
+            return False
+
+    @property
+    def is_pin_set(self):
+        return True
+
+    @property
+    def pin_attempts_left(self):
+        try:
+            resp_data, sw1, sw2 = self.applet.get_card_status()
+            if len(resp_data) >= 8:
+                return resp_data[4]
+        except Exception:
+            pass
+        return None
+
+    @property
+    def pin_attempts_max(self):
+        return 5
+
+    @property
+    def is_locked(self):
+        return not self._pin_unlocked
+
+    @property
+    def is_ready(self):
+        return self.connected and self._pin_unlocked and self.fingerprint is not None
+
+    def _unlock(self, pin):
+        try:
+            success, attempts = self.applet.verify_pin(pin)
+            if success:
+                self._pin_unlocked = True
+                self.enc_secret = tagged_hash('enc', self.secret)
+                return
+        except Exception as e:
+            err = str(e)
+            if err == "9c02":  # wrong PIN
+                attempts = self.pin_attempts_left
+                if attempts is not None and attempts == 0:
+                    raise CriticalErrorWipeImmediately("No more PIN attempts!\nWipe!")
+                raise PinError(
+                    "Invalid PIN!\n%d of %d attempts left..."
+                    % (attempts or 0, self.pin_attempts_max)
+                )
+            elif err == "9c03":  # bricked
+                raise CriticalErrorWipeImmediately("No more PIN attempts!\nWipe!")
+            else:
+                raise e
+
+    def _change_pin(self, old_pin, new_pin):
+        try:
+            self.applet.change_pin(old_pin, new_pin)
+        except Exception as e:
+            err_str = str(e).lower()
+            if '63c' in err_str or 'wrong' in err_str or 'invalid' in err_str:
+                raise PinError("Invalid old PIN!")
+            raise KeyStoreError("Failed to change PIN: %s" % e)
+
+    def lock(self):
+        self._pin_unlocked = False
+
+    async def check_card(self, check_pin=False):
+        try:
+            from platform import hil_test_mode
+        except Exception:
+            hil_test_mode = False
+        if not self.connection.isCardInserted():
+            scr = Progress(
+                "SeedKeeper card not inserted",
+                "Please insert the SeedKeeper card...",
+                button_text="",
+            )
+            asyncio.create_task(self.wait_for_card(scr))
+            await self.show(scr)
+
+        if not self.connected:
+            self.show_loader(title="Connecting to the card...")
+            if hil_test_mode:
+                from debug_trace import log
+                log("SK", "check_card: connecting...")
+            try:
+                self.connection.connect(self.connection.T1_protocol)
+            except Exception as e:
+                if hil_test_mode:
+                    log("SK", "check_card: connect failed: %s" % e)
+                raise KeyStoreError("Failed to communicate with the card.")
+            try:
+                self.applet.select()
+            except Exception as e:
+                if hil_test_mode:
+                    log("SK", "check_card: select failed: %s" % e)
+                raise KeyStoreError("Failed to select the applet")
+            if hil_test_mode:
+                log("SK", "check_card: initiating secure channel...")
+            self.show_loader(title="Establishing secure channel...")
+            self.applet.init_secure_channel()
+            if hil_test_mode:
+                log("SK", "check_card: secure channel established")
+            self.connected = True
+
+        if check_pin and self.is_locked:
+            pin = await self.get_pin()
+            self._unlock(pin)
+
+    async def wait_for_card(self, scr):
+        while not self.connection.isCardInserted():
+            await asyncio.sleep_ms(30)
+            scr.tick(5)
+        if scr.waiting:
+            scr.waiting = False
+
+    async def init(self, show_fn, show_loader):
+        self.show_loader = show_loader
+        self.show = show_fn
+        platform.maybe_mkdir(self.path)
+        self.load_secret(self.path)
+        await self.check_card()
+        await super().init(show_fn, show_loader)
+
+    async def get_pin(self, title="Enter your PIN code", with_cancel=False, note=None):
+        from gui.screens import PinScreen
+        scr = PinScreen(
+            title=title,
+            note=note if note else "Do you recognize these words?",
+            get_word=None,
+            subtitle="SeedKeeper card detected",
+            with_cancel=with_cancel,
+        )
+        return await self.show(scr)
+
+    async def unlock(self):
+        await self.check_card(check_pin=False)
+
+        pin_attempts = self.pin_attempts_left
+
+        while self.is_locked:
+            note = None
+            if pin_attempts is not None:
+                note = "%d PIN attempts remaining" % pin_attempts
+
+            pin = await self.get_pin(note=note)
+            self.show_loader('Verifying PIN code...')
+            try:
+                self._unlock(pin)
+            except PinError as e:
+                await self.show(Alert('PIN Error', str(e)))
+                pin_attempts = self.pin_attempts_left
+                continue
+
+        selected = await self._select_bip39_secret()
+        self.selected_secret_id = selected['id']
+        self.show_loader('Loading mnemonic from card...')
+        mnemonic = self.applet.get_bip39_secret(selected['id'], selected['type'])
+        self.set_mnemonic(mnemonic, "")
+        self._is_key_saved = True
+
+    async def _select_bip39_secret(self):
+        """List BIP39 secrets on card, let user select if multiple.
+        Returns the selected header dict.
+        """
+        headers = self.applet.list_secret_headers()
+        bip39 = [h for h in headers if _is_bip39_header(h)]
+
+        if len(bip39) == 0:
+            raise KeyStoreError("No BIP39 secrets found on card")
+        if len(bip39) == 1:
+            return bip39[0]
+
+        buttons = [
+            (h['id'], h.get('label') or 'Secret #%d' % h['id'])
+            for h in bip39
+        ]
+        selected_id = await self.show(Menu(buttons, title='Select secret', last=(255, None)))
+        if selected_id == 255:
+            raise KeyStoreError("Secret selection cancelled")
+        return next(h for h in bip39 if h['id'] == selected_id)
+
+    async def load_mnemonic(self):
+        await self.check_card(check_pin=True)
+        self.show_loader("Loading secret from the card...")
+
+        try:
+            selected = await self._select_bip39_secret()
+            self.selected_secret_id = selected['id']
+            mnemonic = self.applet.get_bip39_secret(selected['id'], selected['type'])
+            self.set_mnemonic(mnemonic, "")
+            self._is_key_saved = True
+            return True
+        except AppletException as e:
+            await self.show(Alert('Error', 'Failed to load key from card:\n%s' % str(e)))
+            return False
+        except KeyStoreError as e:
+            await self.show(Alert('Error', str(e)))
+            return False
+
+    async def save_mnemonic(self):
+        await self.show(Alert(
+            "Read-only",
+            "SeedKeeper is a read-only device.\n"
+            "Keys are generated and stored on the card."
+        ))
+        raise KeyStoreError("SeedKeeper is read-only")
+
+    @property
+    def is_key_saved(self):
+        return self._is_key_saved
+
+    async def storage_menu(self):
+        enabled = self.connection.isCardInserted()
+        buttons = [
+            (None, "SeedKeeper storage"),
+            (0, "Load key from SeedKeeper", enabled),
+            (1, "Card info", enabled),
+        ]
+
+        while True:
+            menuitem = await self.show(Menu(buttons, last=(255, None)))
+            if menuitem == 255:
+                return False
+            elif menuitem == 0:
+                await self.load_mnemonic()
+                await self.show(
+                    Alert("Success!", "Your key is loaded from SeedKeeper.", button_text="OK")
+                )
+                return True
+            elif menuitem == 1:
+                await self.show_card_info()
+            else:
+                raise KeyStoreError("Invalid menu")
+
+    async def show_card_info(self):
+        try:
+            props = []
+
+            card_label = None
+            try:
+                card_label = self.applet.get_card_label()
+            except Exception:
+                pass
+
+            props.extend([
+                "\n#7f8fa4 PLATFORM #",
+                "Implementation: %s" % self.applet.platform,
+                "Version: %s v%s" % (self.applet.NAME, self.applet.version),
+            ])
+            if card_label:
+                props.append("Card label: %s" % card_label)
+
+            status = self.applet.get_seedkeeper_status()
+            if status:
+                props.extend([
+                    "\n#7f8fa4 STORAGE INFO #",
+                    "Secrets stored: %d" % status.get('nb_secrets', 0),
+                ])
+                total_mem = status.get('total_memory', 0)
+                free_mem = status.get('free_memory', 0)
+                if total_mem > 0:
+                    props.append("Memory used: %d / %d bytes" % (total_mem - free_mem, total_mem))
+
+            try:
+                headers = self.applet.list_secret_headers()
+                secret_types = {}
+                for h in headers:
+                    t = h['type']
+                    if t not in secret_types:
+                        secret_types[t] = []
+                    secret_types[t].append(h)
+
+                if secret_types:
+                    type_names = {
+                        0x10: "Masterseed", 0x30: "BIP39", 0x31: "BIP39 v2",
+                        0x40: "Electrum", 0x50: "Shamir", 0x90: "Password",
+                        0xC0: "Data", 0xC1: "Descriptor",
+                    }
+                    props.append("\n#7f8fa4 SECRETS BY TYPE #")
+                    for t, secrets in sorted(secret_types.items()):
+                        tname = type_names.get(t, "0x%02X" % t)
+                        props.append("%s: %d" % (tname, len(secrets)))
+            except Exception:
+                pass
+
+            scr = Alert("SeedKeeper info", "\n\n".join(props))
+            scr.message.set_recolor(True)
+            await self.show(scr)
+        except Exception as e:
+            await self.show(Alert("Error", "Failed to get card info:\n%s" % str(e)))

--- a/src/keystore/seedkeeper.py
+++ b/src/keystore/seedkeeper.py
@@ -107,19 +107,20 @@ class SeedKeeper(RAMKeyStore):
             success, attempts = self.applet.verify_pin(pin)
             if success:
                 self._pin_unlocked = True
+                self._last_pin = pin
                 self.enc_secret = tagged_hash('enc', self.secret)
                 return
         except Exception as e:
             err = str(e)
-            if err == "9c02":  # wrong PIN
-                attempts = self.pin_attempts_left
+            if err.startswith("63c") and len(err) == 4:
+                attempts = int(err[3], 16)
                 if attempts == 0:
                     raise CriticalErrorWipeImmediately("No more PIN attempts!\nWipe!")
                 raise PinError(
                     "Invalid PIN!\n%d of %d attempts left..."
                     % (attempts, self.pin_attempts_max)
                 )
-            elif err == "9c03":  # bricked
+            elif err == "9c03":
                 raise CriticalErrorWipeImmediately("No more PIN attempts!\nWipe!")
             else:
                 raise e
@@ -232,12 +233,23 @@ class SeedKeeper(RAMKeyStore):
                 pin_attempts = self.pin_attempts_left
                 continue
 
-        selected = await self._select_bip39_secret()
-        self.selected_secret_id = selected['id']
-        self.show_loader('Loading mnemonic from card...')
-        mnemonic = self.applet.get_bip39_secret(selected['id'], selected['type'])
-        self.set_mnemonic(mnemonic, "")
-        self._is_key_saved = True
+        try:
+            selected = await self._select_bip39_secret()
+            self.selected_secret_id = selected['id']
+            self.show_loader('Loading mnemonic from card...')
+            mnemonic = self.applet.get_bip39_secret(selected['id'], selected['type'])
+            self.set_mnemonic(mnemonic, "")
+            self._is_key_saved = True
+        except KeyStoreError as e:
+            if "No BIP39 secrets" in str(e):
+                await self.show(Alert(
+                    'No secrets',
+                    'No BIP39 secrets found on the card.\n'
+                    'Go to Settings > SeedKeeper storage\n'
+                    'to import a secret.'
+                ))
+                return
+            raise
 
     async def _select_bip39_secret(self):
         """List BIP39 secrets on card, let user select if multiple.

--- a/src/keystore/seedkeeper.py
+++ b/src/keystore/seedkeeper.py
@@ -6,8 +6,10 @@ from .javacard.util import get_connection
 from platform import CriticalErrorWipeImmediately
 import platform
 from helpers import tagged_hash
-from gui.screens import Alert, Progress, Menu
+from gui.screens import Alert, Progress, Menu, Prompt
+from binascii import hexlify
 import asyncio
+import secp256k1
 
 
 class SeedKeeper(RAMKeyStore):
@@ -68,7 +70,7 @@ class SeedKeeper(RAMKeyStore):
                 return resp_data[4]
         except Exception:
             pass
-        return None
+        return 0
 
     @property
     def pin_attempts_max(self):
@@ -82,6 +84,24 @@ class SeedKeeper(RAMKeyStore):
     def is_ready(self):
         return self.connected and self._pin_unlocked and self.fingerprint is not None
 
+    def ping(self):
+        try:
+            self.applet.get_card_status()
+        except Exception:
+            self.connected = False
+
+    @property
+    def userkey(self):
+        if self._userkey is None:
+            card_key = self.applet.sc.card_pubkey
+            if card_key is not None:
+                pub_bytes = secp256k1.ec_pubkey_serialize(card_key)
+                card_key_bytes = pub_bytes
+            else:
+                card_key_bytes = b""
+            self._userkey = tagged_hash("userkey", self.secret + card_key_bytes)
+        return self._userkey
+
     def _unlock(self, pin):
         try:
             success, attempts = self.applet.verify_pin(pin)
@@ -93,11 +113,11 @@ class SeedKeeper(RAMKeyStore):
             err = str(e)
             if err == "9c02":  # wrong PIN
                 attempts = self.pin_attempts_left
-                if attempts is not None and attempts == 0:
+                if attempts == 0:
                     raise CriticalErrorWipeImmediately("No more PIN attempts!\nWipe!")
                 raise PinError(
                     "Invalid PIN!\n%d of %d attempts left..."
-                    % (attempts or 0, self.pin_attempts_max)
+                    % (attempts, self.pin_attempts_max)
                 )
             elif err == "9c03":  # bricked
                 raise CriticalErrorWipeImmediately("No more PIN attempts!\nWipe!")
@@ -115,6 +135,12 @@ class SeedKeeper(RAMKeyStore):
 
     def lock(self):
         self._pin_unlocked = False
+        self.applet.sc.reset()
+        try:
+            self.connection.disconnect()
+        except Exception:
+            pass
+        self.connected = False
 
     async def check_card(self, check_pin=False):
         try:
@@ -129,6 +155,11 @@ class SeedKeeper(RAMKeyStore):
             )
             asyncio.create_task(self.wait_for_card(scr))
             await self.show(scr)
+
+        try:
+            self.ping()
+        except Exception:
+            pass
 
         if not self.connected:
             self.show_loader(title="Connecting to the card...")
@@ -188,12 +219,9 @@ class SeedKeeper(RAMKeyStore):
     async def unlock(self):
         await self.check_card(check_pin=False)
 
-        pin_attempts = self.pin_attempts_left
-
         while self.is_locked:
-            note = None
-            if pin_attempts is not None:
-                note = "%d PIN attempts remaining" % pin_attempts
+            pin_attempts = self.pin_attempts_left
+            note = "%d PIN attempts remaining" % pin_attempts
 
             pin = await self.get_pin(note=note)
             self.show_loader('Verifying PIN code...')
@@ -262,16 +290,26 @@ class SeedKeeper(RAMKeyStore):
     def is_key_saved(self):
         return self._is_key_saved
 
+    @property
+    def hexid(self):
+        card_key = self.applet.sc.card_pubkey
+        if card_key is not None:
+            pub_bytes = secp256k1.ec_pubkey_serialize(card_key)
+            return hexlify(tagged_hash("seedkeeper/pubkey", pub_bytes)[:4]).decode()
+        return "????????"
+
     async def storage_menu(self):
         enabled = self.connection.isCardInserted()
         buttons = [
             (None, "SeedKeeper storage"),
             (0, "Load key from SeedKeeper", enabled),
-            (1, "Card info", enabled),
+            (1, "Use a different card", enabled),
+            (2, "Card info", enabled),
         ]
 
         while True:
-            menuitem = await self.show(Menu(buttons, last=(255, None)))
+            note = "Card fingerprint: %s" % self.hexid
+            menuitem = await self.show(Menu(buttons, note=note, last=(255, None)))
             if menuitem == 255:
                 return False
             elif menuitem == 0:
@@ -281,6 +319,26 @@ class SeedKeeper(RAMKeyStore):
                 )
                 return True
             elif menuitem == 1:
+                if await self.show(
+                    Prompt(
+                        "Switching the card",
+                        "To use a different card you need "
+                        "to provide a PIN for current one first!\n\n"
+                        "Continue?"
+                    )
+                ):
+                    self.lock()
+                    self._userkey = None
+                    await self.show(
+                        Alert(
+                            "Please swap the card",
+                            "Now you can insert another card and set it up.",
+                            button_text="Continue"
+                        )
+                    )
+                    await self.check_card(check_pin=True)
+                    await self.unlock()
+            elif menuitem == 2:
                 await self.show_card_info()
             else:
                 raise KeyStoreError("Invalid menu")

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from gui.specter import SpecterGUI
 from keystore.core import KeyStore
 from keystore.sdcard import SDKeyStore
 from keystore.memorycard import MemoryCard
+from keystore.seedkeeper import SeedKeeper
 
 from hosts import SDHost, QRHost, USBHost, Host
 import platform
@@ -66,6 +67,7 @@ def main(apps=None, network="main", keystore_cls=None):
     else:
         keystores = [
             MemoryCard,
+            SeedKeeper,
             SDKeyStore,
         ]
 

--- a/src/specter.py
+++ b/src/specter.py
@@ -339,6 +339,8 @@ class Specter:
         if self.keystore.is_key_saved and self.keystore.load_button:
             buttons.append((2, self.keystore.load_button))
         buttons += [(None, "Settings"), (3, "Device settings")]
+        if self.keystore.storage_button is not None:
+            buttons.append((4, self.keystore.storage_button))
         # wait for menu selection
         menuitem = await self.gui.menu(buttons)
 
@@ -366,6 +368,11 @@ class Specter:
             return self.mainmenu
         elif menuitem == 3:
             await self.update_devsettings()
+        elif menuitem == 4:
+            res = await self.keystore.storage_menu()
+            if res:
+                self.init_apps()
+                return self.mainmenu
         elif menuitem == 777:
             return await self.import_mnemonic()
         # lock device

--- a/src/specter.py
+++ b/src/specter.py
@@ -24,6 +24,7 @@ from embit import bip39
 from embit.liquid.networks import NETWORKS
 from gui.screens.settings import HostSettings
 from gui.screens.mnemonic import MnemonicPrompt
+from gui.screens.debug_info import DebugInfoScreen
 
 # small helper functions
 from helpers import gen_mnemonic, fix_mnemonic
@@ -162,15 +163,34 @@ class Specter:
             return
         # checking the first available keystore
         keystore_cls = None
-        # TODO: show some screen here if none are available
+        # show debug info screen if multiple keystores (e.g. MemoryCard + SeedKeeper)
+        debug_screen = None
+        connection = None
+        for ks in self.keystores:
+            if hasattr(ks, 'connection'):
+                connection = ks.connection
+                break
+        poll_count = 0
         while keystore_cls is None:
             for keystore in self.keystores:
                 if keystore.is_available():
                     keystore_cls = keystore
                     break
-            # if none are available just wait for it
-            # if keystore_cls is None:
-            #     await asyncio.sleep_ms(50)
+            if keystore_cls is None:
+                # show debug screen on first iteration and every ~5s
+                if debug_screen is None and connection is not None:
+                    from keystore.javacard.card_scanner import scan_card_applets
+                    debug_screen = DebugInfoScreen()
+                    debug_screen.load()
+                if debug_screen is not None and poll_count % 100 == 0:
+                    from keystore.javacard.card_scanner import scan_card_applets
+                    try:
+                        info = scan_card_applets(connection)
+                        debug_screen.update_info(info)
+                    except Exception:
+                        pass
+                await asyncio.sleep_ms(50)
+                poll_count += 1
         self.keystore = keystore_cls()
         self._hil_set_keystore_ref(keystore_cls)
 
@@ -200,7 +220,15 @@ class Specter:
             await self.keystore.init(self.gui.show_screen(), self.gui.show_loader)
             # unlock with PIN or set up the PIN code
             await self.unlock()
+            # initialize apps if keystore loaded a key during unlock
+            # (needed for keystores like SeedKeeper that auto-load mnemonic)
+            if self.keystore.fingerprint is not None:
+                self.init_apps()
+                self.current_menu = self.mainmenu
         except Exception as e:
+            if hil_test_mode:
+                from debug_trace import log_exception
+                log_exception("SETUP", e)
             next_fn = await self.handle_exception(e, self.setup)
             await next_fn()
 

--- a/test/hil/controller.py
+++ b/test/hil/controller.py
@@ -156,6 +156,16 @@ class SerialSocket:
             expected_prefix = b"OK:KEYSTORE"
         elif cmd.startswith("TEST_FINGERPRINT"):
             expected_prefix = b"OK:FINGERPRINT"
+        elif cmd.startswith("TEST_IMPORT_SECRET"):
+            expected_prefix = b"OK:IMPORT"
+        elif cmd.startswith("TEST_DELETE_SECRET"):
+            expected_prefix = b"OK:DELETED"
+        elif cmd.startswith("TEST_CARD_RESET"):
+            expected_prefix = b"OK:CARD_RESET"
+        elif cmd.startswith("TEST_SECRETS"):
+            expected_prefix = b"OK:SECRETS"
+        elif cmd.startswith("TEST_ALL_SECRETS"):
+            expected_prefix = b"OK:ALL_SECRETS"
         return self.read_response(timeout=timeout, expected_prefix=expected_prefix)
 
     def send(self, cmd):
@@ -314,14 +324,33 @@ class HardwareController:
 
     def _load_seedkeeper(self):
         """Load mnemonic from SeedKeeper card via HIL."""
-        self._send_with_retry("1234", "PIN entry", require_change=True)
+        self._send_with_retry("1234", "PIN entry", require_change=False)
+        time.sleep(1)
         for i in range(30):
             resp = self.gui.command("TEST_SCREEN", timeout=2)
             if b"OK:SCREEN:Menu:" in resp:
                 if b"Select secret" in resp:
                     self._select_secret_by_label("abandon")
                     time.sleep(3)
+                    resp = self.gui.command("TEST_SCREEN", timeout=2)
+                    if b"OK:SCREEN:Menu:" in resp and b"Select secret" not in resp:
+                        print("  Reached main menu (SeedKeeper)")
+                        return
                     continue
+                if b"What do you want to do" in resp:
+                    print("  No secrets on card, importing abandon mnemonic...")
+                    self.card_import_bip39("abandon " * 11 + "about", label="abandon")
+                    print("  Resetting device to load imported secret...")
+                    self.gui.command("TEST_RESET", timeout=5)
+                    time.sleep(4)
+                    self.gui._reopen()
+                    for j in range(30):
+                        r = self.gui.status()
+                        if b"OK:READY" in r:
+                            break
+                        time.sleep(0.5)
+                    print("  Re-entering _load_seedkeeper after import...")
+                    return self._load_seedkeeper()
                 print("  Reached main menu (SeedKeeper)")
                 return
             elif b"OK:SCREEN:Alert:" in resp:
@@ -347,6 +376,64 @@ class HardwareController:
             target_id = int(parts[0].decode().split(":")[0])
         print(f"  Selecting secret: {label} (id={target_id})")
         self.gui.send(target_id)
+
+    def card_import_bip39(self, mnemonic, label=""):
+        """Import a BIP39 mnemonic to the SeedKeeper card via HIL.
+
+        Converts mnemonic to entropy, sends TEST_IMPORT_SECRET command.
+        Returns (secret_id, fingerprint_hex) tuple.
+        """
+        import embit
+        from binascii import hexlify
+        from embit import bip39
+        entropy = bip39.mnemonic_to_bytes(mnemonic)
+        entropy_len = len(entropy)
+        secret_data = bytes([entropy_len >> 8, entropy_len & 0xFF]) + entropy
+        hex_data = hexlify(secret_data).decode()
+        cmd = "TEST_IMPORT_SECRET:%s" % hex_data
+        if label:
+            cmd += ":%s" % label
+        resp = self.gui.command(cmd, timeout=10)
+        prefix = b"OK:IMPORT:"
+        if prefix not in resp:
+            raise RuntimeError("Import failed: %s" % resp)
+        parts = resp.split(prefix, 1)[1].strip().split(b":")
+        sid = int(parts[0])
+        fp = parts[1].decode()
+        print(f"  Imported secret: id={sid}, fingerprint={fp}")
+        return sid, fp
+
+    def card_delete_secret(self, sid):
+        """Delete a secret from the SeedKeeper card by ID."""
+        resp = self.gui.command("TEST_DELETE_SECRET:%d" % sid, timeout=5)
+        prefix = b"OK:DELETED:"
+        if prefix not in resp:
+            raise RuntimeError("Delete failed: %s" % resp)
+        print(f"  Deleted secret: id={sid}")
+        return True
+
+    def card_delete_all_secrets(self):
+        """Delete all BIP39 secrets from the card."""
+        resp = self.gui.command("TEST_ALL_SECRETS", timeout=5)
+        if b"OK:ALL_SECRETS:" not in resp:
+            print("  No secrets to delete")
+            return
+        parts = resp.split(b"OK:ALL_SECRETS:")[1].strip().split(b",")
+        bip39_types = (0x10, 0x30, 0x31)
+        for part in parts:
+            fields = part.decode().split(":")
+            sid = int(fields[0])
+            tname = fields[1]
+            try:
+                tval = int(tname, 16) if tname.startswith("0x") else 0
+            except ValueError:
+                tval = 0
+            is_bip39 = tval in bip39_types
+            if tname in ("MASTERSEED", "BIP39", "BIP39v2"):
+                is_bip39 = True
+            if is_bip39:
+                self.card_delete_secret(sid)
+        print("  All BIP39 secrets deleted")
 
     @staticmethod
     def _find_stlink_uart():
@@ -499,7 +586,7 @@ class HardwareController:
         self.keystore_type = self._detect_keystore(timeout=30)
         print("Detected keystore: %s" % self.keystore_type)
 
-        if self.keystore_type == "seedkeeper":
+        if self.keystore_type.lower() == "seedkeeper":
             self._load_seedkeeper()
         else:
             self._load_internal_flash()

--- a/test/hil/controller.py
+++ b/test/hil/controller.py
@@ -312,6 +312,42 @@ class HardwareController:
         print("Keystore detection timed out, defaulting to internal")
         return "internal"
 
+    def _load_seedkeeper(self):
+        """Load mnemonic from SeedKeeper card via HIL."""
+        self._send_with_retry("1234", "PIN entry", require_change=True)
+        for i in range(30):
+            resp = self.gui.command("TEST_SCREEN", timeout=2)
+            if b"OK:SCREEN:Menu:" in resp:
+                if b"Select secret" in resp:
+                    self._select_secret_by_label("abandon")
+                    time.sleep(3)
+                    continue
+                print("  Reached main menu (SeedKeeper)")
+                return
+            elif b"OK:SCREEN:Alert:" in resp:
+                self.gui.send(True)
+                time.sleep(0.5)
+            time.sleep(0.3)
+        raise RuntimeError("Did not reach main menu after SeedKeeper PIN")
+
+    def _select_secret_by_label(self, label):
+        """Select a BIP39 secret by label via TEST_SECRETS command."""
+        resp = self.gui.command("TEST_SECRETS", timeout=5)
+        if b"OK:SECRETS:" not in resp:
+            self.gui.send(1)
+            return
+        parts = resp.split(b"OK:SECRETS:")[1].strip().split(b",")
+        target_id = None
+        for part in parts:
+            fields = part.decode().split(":")
+            if len(fields) >= 2 and fields[1] == label:
+                target_id = int(fields[0])
+                break
+        if target_id is None:
+            target_id = int(parts[0].decode().split(":")[0])
+        print(f"  Selecting secret: {label} (id={target_id})")
+        self.gui.send(target_id)
+
     @staticmethod
     def _find_stlink_uart():
         matches = sorted(glob.glob("/dev/serial/by-id/usb-STMicroelectronics_STM32_STLink_*-if02"))
@@ -460,7 +496,13 @@ class HardwareController:
         else:
             raise RuntimeError("Device not ready after wipe")
 
-        self._load_internal_flash()
+        self.keystore_type = self._detect_keystore(timeout=30)
+        print("Detected keystore: %s" % self.keystore_type)
+
+        if self.keystore_type == "seedkeeper":
+            self._load_seedkeeper()
+        else:
+            self._load_internal_flash()
         self._wait_for_usb_vcp()
 
     def shutdown(self):

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -7,3 +7,18 @@ To run launch with python3 from this folder (you should have `micropython_unix` 
 ```
 python3 run_tests.py
 ```
+
+## Hardware-in-the-Loop (HIL) tests
+
+Tests run against real STM32F469 hardware via the debug UART (ST-Link VCP).
+
+Prerequisites:
+- Device flashed with HIL firmware: `make hardwareintheloop`
+- ST-Link connected (debug UART on `/dev/ttyACM0`)
+- Bitcoin Core running in regtest mode (for RPC tests)
+
+```
+make hardwareintheloop-test
+```
+
+The full suite (16 tests) takes approximately **6 minutes** to complete.

--- a/test/integration/hardwareintheloop.py
+++ b/test/integration/hardwareintheloop.py
@@ -69,6 +69,7 @@ def main():
 
         test_files = [
             ("test_basic", "test_basic.py"),
+            ("test_seedkeeper", "test_seedkeeper.py"),
         ]
 
         if rpc_available():

--- a/test/integration/tests/test_seedkeeper.py
+++ b/test/integration/tests/test_seedkeeper.py
@@ -1,0 +1,55 @@
+"""
+SeedKeeper HIL tests.
+
+All tests are skipped unless a SeedKeeper card is detected by the
+HardwareController at load time. When no card is present (or T=1
+USART fix is not available), SeedKeeper.is_available() returns False,
+the controller falls back to internal flash, and has_seedkeeper()
+returns False — so every test here is skipped with zero impact.
+"""
+from unittest import TestCase, skipUnless
+from util.controller import sim
+
+
+def has_seedkeeper():
+    return hasattr(sim, 'keystore_type') and sim.keystore_type.lower() == "seedkeeper"
+
+
+@skipUnless(has_seedkeeper(), "SeedKeeper card not detected")
+class SeedKeeperTest(TestCase):
+
+    def test_get_fingerprint(self):
+        res = sim.query(b"fingerprint")
+        self.assertEqual(len(res), 8, "fingerprint should be 8 hex chars, got: %s" % repr(res))
+        int(res, 16)
+
+    def test_fingerprint_stable(self):
+        fp1 = sim.query(b"fingerprint")
+        fp2 = sim.query(b"fingerprint")
+        self.assertEqual(fp1, fp2, "fingerprint should be stable: %s vs %s" % (fp1, fp2))
+
+    def test_get_xpub(self):
+        res = sim.query(b"xpub m/44h/1h/0h")
+        self.assertTrue(res.startswith(b"tpub") or res.startswith(b"xpub"),
+                        "expected xpub, got: %s" % repr(res))
+
+    def test_xpub_multiple_paths(self):
+        xpub1 = sim.query(b"xpub m/44h/0h/0h")
+        xpub2 = sim.query(b"xpub m/49h/0h/0h")
+        self.assertNotEqual(xpub1, xpub2,
+                            "different derivation paths should give different xpubs")
+
+    def test_read_only_mnemonic_import(self):
+        res = sim.query(b"set_mnemonic abandon about abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+        self.assertTrue(b"error" in res.lower() or b"invalid" in res,
+                        "expected error for mnemonic import, got: %s" % repr(res))
+
+    def test_card_secrets_list(self):
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        self.assertIn(b"OK:SECRETS", resp,
+                      "TEST_SECRETS should return OK:SECRETS, got: %s" % repr(resp))
+
+    def test_card_all_secrets_list(self):
+        resp = sim.gui.command("TEST_ALL_SECRETS", timeout=5)
+        self.assertIn(b"OK:ALL_SECRETS", resp,
+                      "TEST_ALL_SECRETS should return OK:ALL_SECRETS, got: %s" % repr(resp))

--- a/test/integration/tests/test_seedkeeper.py
+++ b/test/integration/tests/test_seedkeeper.py
@@ -11,6 +11,10 @@ from unittest import TestCase, skipUnless
 from util.controller import sim
 
 
+MNEMONIC_ABANDON = "abandon " * 11 + "about"
+MNEMONIC_BACON = "bacon " * 11 + "about"
+
+
 def has_seedkeeper():
     return hasattr(sim, 'keystore_type') and sim.keystore_type.lower() == "seedkeeper"
 
@@ -53,3 +57,68 @@ class SeedKeeperTest(TestCase):
         resp = sim.gui.command("TEST_ALL_SECRETS", timeout=5)
         self.assertIn(b"OK:ALL_SECRETS", resp,
                       "TEST_ALL_SECRETS should return OK:ALL_SECRETS, got: %s" % repr(resp))
+
+    def test_import_bacon_secret(self):
+        """Import 'bacon' mnemonic and verify it appears on the card."""
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        secrets_part = resp.decode().split("OK:SECRETS:")[1] if "OK:SECRETS:" in resp.decode() else ""
+        for entry in secrets_part.split(","):
+            fields = entry.strip().split(":")
+            if len(fields) >= 2 and fields[1] == "bacon":
+                self.skipTest("'bacon' secret already exists on card")
+
+        sid, fp = sim.card_import_bip39(MNEMONIC_BACON, label="bacon")
+        self.assertEqual(len(fp), 8, "fingerprint should be 8 hex chars")
+        int(fp, 16)
+
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        self.assertIn(b"bacon", resp, "'bacon' secret should appear after import")
+
+    def test_delete_and_restore_secret(self):
+        """Delete the 'abandon' secret, verify it's gone, then restore it."""
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        self.assertIn(b"OK:SECRETS", resp)
+
+        resp_str = resp.decode()
+        secrets_part = resp_str.split("OK:SECRETS:")[1] if "OK:SECRETS:" in resp_str else ""
+        abandon_id = None
+        if secrets_part.strip():
+            for entry in secrets_part.split(","):
+                fields = entry.strip().split(":")
+                if len(fields) >= 2 and fields[1] == "abandon":
+                    abandon_id = int(fields[0])
+                    break
+
+        if abandon_id is None:
+            self.skipTest("'abandon' secret not found on card")
+
+        sim.card_delete_secret(abandon_id)
+
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        secrets_part = resp.decode().split("OK:SECRETS:")[1] if "OK:SECRETS:" in resp.decode() else ""
+        for entry in secrets_part.split(","):
+            fields = entry.strip().split(":")
+            if len(fields) >= 1:
+                self.assertNotEqual(int(fields[0]), abandon_id,
+                                    "deleted secret should not appear in list")
+
+        sid, fp = sim.card_import_bip39(MNEMONIC_ABANDON, label="abandon")
+        self.assertEqual(len(fp), 8, "restored secret should have valid fingerprint")
+
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        self.assertIn(b"abandon", resp, "'abandon' secret should be restored")
+
+    def test_delete_all_and_restore(self):
+        """Delete all BIP39 secrets, verify card is empty, then restore abandon.
+        Runs last to avoid destroying card state for other tests.
+        """
+        sim.card_delete_all_secrets()
+
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        secrets_part = resp.decode().split("OK:SECRETS:")[1] if "OK:SECRETS:" in resp.decode() else ""
+        self.assertEqual(secrets_part.strip(), "",
+                         "all BIP39 secrets should be deleted")
+
+        sim.card_import_bip39(MNEMONIC_ABANDON, label="abandon")
+        resp = sim.gui.command("TEST_SECRETS", timeout=5)
+        self.assertIn(b"abandon", resp, "'abandon' secret should be restored")


### PR DESCRIPTION
## Summary

Adds SeedKeeper — a smartcard-based keystore that stores encrypted BIP39 mnemonics on JavaCard — as a new keystore option in Specter-DIY.

- **SeedKeeper extends RAMKeyStore** directly, mirroring the existing MemoryCard architecture (no shared JavaCardKeyStore base class)
- **Satochip secure channel** (ECDH + AES-CBC + HMAC-SHA1) for encrypted card communication
- **Multi-secret support** — card holds multiple BIP39 secrets; user selects which to load at boot
- **Read-only** — secrets are generated/stored on the card, not saved from the device

## New files

| File | Purpose |
|------|---------|
| `src/keystore/seedkeeper.py` | SeedKeeper keystore (RAMKeyStore subclass) |
| `src/keystore/javacard/applets/satochip_securechannel.py` | ECDH + AES-CBC + HMAC-SHA1 |
| `src/keystore/javacard/applets/seedkeeper_applet.py` | APDU commands (PIN, secrets, status) |
| `src/keystore/javacard/card_scanner.py` | Card AID probe utility |
| `src/gui/screens/debug_info.py` | Firmware version + card/applet status screen |
| `test/integration/tests/test_seedkeeper.py` | 6 HIL tests (skipUnless SeedKeeper) |

## Modified files

| File | Change |
|------|--------|
| `src/keystore/memorycard.py` | Add `disconnect()` in except block of `is_available()` |
| `src/main.py` | Import SeedKeeper, add after MemoryCard in keystores list |
| `src/specter.py` | DebugInfoScreen, sleep_ms(50) in polling, init_apps()+mainmenu after unlock |
| `src/hil.py` | TEST_SECRETS / TEST_ALL_SECRETS HIL commands |
| `test/hil/controller.py` | `_detect_keystore()`, `_load_seedkeeper()`, `_select_secret_by_label()` |

## Key design decisions

1. **HMAC-SHA1 in pure Python** — MicroPython's `hmac` module lacks SHA1; implemented via `hashlib.sha1()` (C-accelerated from `uhashlib` usermod). See #20
2. **`get_word=None`** for SeedKeeper PIN screen — no anti-phishing words (card doesn't support them)
3. **`init_apps()` after unlock** — USB commands need keystore-loaded apps. See #18
4. **Debug traces** — conditional on `hil_test_mode`, no impact on production firmware

## Testing

All tests use the `abandon * 11 + about` mnemonic (fingerprint `73c5da0a`). The SeedKeeper card must be provisioned with this mnemonic under label `abandon`.

```
make hil        # Build HIL firmware (boot/main + HIL=1)
make hilflash   # Build + flash
make hiltest    # Run integration tests
```

| Suite | Result |
|-------|--------|
| test_basic.py (3 tests) | 3/3 pass |
| test_seedkeeper.py (6 tests) | 6/6 pass |
| test_with_rpc.py (14 tests) | 11+ pass (2 pre-existing failures) |

## Related

- Depends on #18 (init_apps bugfix)
- Related to #19 (comparative analysis)
- Related to #20 (HMAC-SHA1 MicroPython)